### PR TITLE
Keywords Fix and Refactoring

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,8 @@ readme = "README.md"
 build = "src/build_metrics.rs"
 
 [build-dependencies]
-lazy_static = "0.2"
+lazy_static = "1.2"
 
 [dependencies]
-lazy_static = "0.2"
+lazy_static = "1.2"
 time = "0.1"

--- a/src/build_metrics.rs
+++ b/src/build_metrics.rs
@@ -33,8 +33,7 @@ fn write_cond(f: &mut File, name: &str, encoding: &Encoding) -> Result<()> {
             }
         }
     }
-    writeln!(f, "]);")?;
-    Ok(())
+    writeln!(f, "]);")
 }
 
 fn main() {
@@ -78,7 +77,7 @@ fn main() {
          lazy_static! {{",
     )
     .unwrap();
-    for font in textfonts.iter() {
+    for font in &textfonts {
         write_cond(f, font, &WIN_ANSI_ENCODING).unwrap();
     }
     write_cond(f, "Symbol", &SYMBOL_ENCODING).unwrap();

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -33,7 +33,7 @@ impl<'a> Canvas<'a> {
             outline_items,
         }
     }
-    
+
     /// Append a closed rectangle with a corner at (x, y) and
     /// extending width × height to the to the current path.
     pub fn rectangle(

--- a/src/canvas.rs
+++ b/src/canvas.rs
@@ -20,20 +20,20 @@ pub struct Canvas<'a> {
     outline_items: &'a mut Vec<OutlineItem>,
 }
 
-// Should not be called by user code.
-pub fn create_canvas<'a>(
-    output: &'a mut Write,
-    fonts: &'a mut HashMap<BuiltinFont, FontRef>,
-    outline_items: &'a mut Vec<OutlineItem>,
-) -> Canvas<'a> {
-    Canvas {
-        output,
-        fonts,
-        outline_items,
-    }
-}
-
 impl<'a> Canvas<'a> {
+    // Should not be called by user code.
+    pub(crate) fn new(
+        output: &'a mut Write,
+        fonts: &'a mut HashMap<BuiltinFont, FontRef>,
+        outline_items: &'a mut Vec<OutlineItem>,
+    ) -> Self {
+        Canvas {
+            output,
+            fonts,
+            outline_items,
+        }
+    }
+    
     /// Append a closed rectangle with a corner at (x, y) and
     /// extending width × height to the to the current path.
     pub fn rectangle(
@@ -163,8 +163,7 @@ impl<'a> Canvas<'a> {
         self.curve_to(leftp, top, left, up, left, y)?;
         self.curve_to(left, down, leftp, bottom, x, bottom)?;
         self.curve_to(rightp, bottom, right, down, right, y)?;
-        self.curve_to(right, up, rightp, top, x, top)?;
-        Ok(())
+        self.curve_to(right, up, rightp, top, x, top)
     }
     /// Stroke the current path.
     pub fn stroke(&mut self) -> io::Result<()> {
@@ -180,12 +179,11 @@ impl<'a> Canvas<'a> {
     }
     /// Get a FontRef for a specific font.
     pub fn get_font(&mut self, font: BuiltinFont) -> FontRef {
-        use fontref::create_font_ref;
         let next_n = self.fonts.len();
         self.fonts
             .entry(font)
             .or_insert_with(|| {
-                create_font_ref(
+                FontRef::new(
                     next_n,
                     font.get_encoding().clone(),
                     Arc::new(font.get_metrics()),
@@ -204,9 +202,8 @@ impl<'a> Canvas<'a> {
     where
         F: FnOnce(&mut TextObject) -> io::Result<T>,
     {
-        use textobject::create_text_object;
         writeln!(self.output, "BT")?;
-        let result = render_text(&mut create_text_object(self.output))?;
+        let result = render_text(&mut TextObject::new(self.output))?;
         writeln!(self.output, "ET")?;
         Ok(result)
     }

--- a/src/encoding.rs
+++ b/src/encoding.rs
@@ -46,10 +46,7 @@ impl Encoding {
     /// assert_eq!(None,      enc.get_code("☺"));
     /// ````
     pub fn get_code(&self, name: &str) -> Option<u8> {
-        match self.name_to_code.get(name) {
-            Some(&code) => Some(code),
-            None => None,
-        }
+        self.name_to_code.get(name).cloned()
     }
 
     /// Get the encoded code point from a (unicode) character.
@@ -88,7 +85,12 @@ impl Encoding {
     ///            symb_enc.encode_string("α ∈ ℜ"));
     /// ````
     pub fn encode_string(&self, text: &str) -> Vec<u8> {
-        let mut result = Vec::new();
+        let size = text.len()
+            + text
+                .chars()
+                .filter(|&c| c == '\\' || c == '(' || c == ')')
+                .count();
+        let mut result = Vec::with_capacity(size);
         for ch in text.chars() {
             match self.encode_char(ch) {
                 Some(b'\\') => {
@@ -110,11 +112,9 @@ impl Encoding {
         result
     }
 
-    fn init_block(&mut self, start: u8, data: Vec<&'static str>) {
-        let mut i = start - 1;
-        for name in data {
-            i += 1;
-            self.name_to_code.insert(name, i);
+    fn init_block(&mut self, start: u8, data: &[&'static str]) {
+        for (i, name) in data.iter().enumerate() {
+            self.name_to_code.insert(name, start + (i as u8));
         }
     }
 }
@@ -159,78 +159,78 @@ lazy_static! {
             name_to_code: BTreeMap::new(),
             unicode_to_code: codes
         };
-        result.init_block(0o40, vec!(
+        result.init_block(0o40, &[
             "space", "exclam", "quotedbl", "numbersign",
-            "dollar", "percent", "ampersand", "quotesingle"));
-        result.init_block(0o50, vec!(
+            "dollar", "percent", "ampersand", "quotesingle"]);
+        result.init_block(0o50, &[
             "parenleft", "parenright", "asterisk", "plus",
-            "comma", "hyphen", "period", "slash"));
-        result.init_block(0o60, vec!(
-            "zero", "one", "two", "three", "four", "five", "six", "seven"));
-        result.init_block(0o70, vec!(
+            "comma", "hyphen", "period", "slash"]);
+        result.init_block(0o60, &[
+            "zero", "one", "two", "three", "four", "five", "six", "seven"]);
+        result.init_block(0o70, &[
             "eight", "nine", "colon", "semicolon",
-            "less", "equal", "greater", "question"));
-        result.init_block(0o100, vec!(
+            "less", "equal", "greater", "question"]);
+        result.init_block(0o100, &[
             "at", "A", "B", "C", "D", "E", "F", "G", "H", "I", "J",
             "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V",
-            "W", "X", "Y", "Z"));
-        result.init_block(0o133, vec!(
+            "W", "X", "Y", "Z"]);
+        result.init_block(0o133, &[
             "bracketleft",
-            "backslash", "bracketright", "asciicircum", "underscore"));
-        result.init_block(0o140, vec!(
+            "backslash", "bracketright", "asciicircum", "underscore"]);
+        result.init_block(0o140, &[
             "grave", "a", "b", "c", "d", "e", "f", "g", "h", "i", "j",
             "k", "l", "m", "n", "o", "p", "q", "r", "s", "t", "u", "v",
-            "w", "x", "y", "z"));
-        result.init_block(0o173, vec!(
-            "braceleft", "bar", "braceright", "asciitilde"));
-        result.init_block(0o200, vec!(
+            "w", "x", "y", "z"]);
+        result.init_block(0o173, &[
+            "braceleft", "bar", "braceright", "asciitilde"]);
+        result.init_block(0o200, &[
             "Euro", "..1", "quotesinglbase", "florin",
-            "quotedblbase", "ellipsis", "dagger", "daggerdbl"));
-        result.init_block(0o210, vec!(
+            "quotedblbase", "ellipsis", "dagger", "daggerdbl"]);
+        result.init_block(0o210, &[
             "circumflex", "perthousand", "Scaron", "guilsinglleft",
-            "OE", "..5", "Zcaron", "..7"));
-        result.init_block(0o220, vec!(
+            "OE", "..5", "Zcaron", "..7"]);
+        result.init_block(0o220, &[
             "..0", "quoteleft", "quoteright", "quotedblleft",
-            "quotedblright", "bullet", "endash", "emdash"));
-        result.init_block(0o230, vec!(
+            "quotedblright", "bullet", "endash", "emdash"]);
+        result.init_block(0o230, &[
             "tilde", "trademark", "scaron", "guilsinglright",
-            "oe", "..5", "zcaron", "Ydieresis"));
-        result.init_block(0o240, vec!(
+            "oe", "..5", "zcaron", "Ydieresis"]);
+        result.init_block(0o240, &[
             "..0", "exclamdown", "cent", "sterling",
-            "currency", "yen", "brokenbar", "section"));
-        result.init_block(0o250, vec!(
+            "currency", "yen", "brokenbar", "section"]);
+        result.init_block(0o250, &[
             "dieresis", "copyright", "ordfeminine", "guillemotleft",
-            "logicalnot", "..5", "registered", "macron"));
-        result.init_block(0o260, vec!(
+            "logicalnot", "..5", "registered", "macron"]);
+        result.init_block(0o260, &[
             "degree", "plusminus", "twosuperior", "threesuperior",
-            "acute", "mu", "paragraph", "periodcentered"));
-        result.init_block(0o270, vec!(
+            "acute", "mu", "paragraph", "periodcentered"]);
+        result.init_block(0o270, &[
             "cedilla", "onesuperior", "ordmasculine", "guillemotright",
-            "onequarter", "onehalf", "threequarters", "questiondown"));
-        result.init_block(0o300, vec!(
+            "onequarter", "onehalf", "threequarters", "questiondown"]);
+        result.init_block(0o300, &[
             "Agrave", "Aacute", "Acircumflex", "Atilde",
-            "Adieresis", "Aring", "AE", "Ccedilla"));
-        result.init_block(0o310, vec!(
+            "Adieresis", "Aring", "AE", "Ccedilla"]);
+        result.init_block(0o310, &[
             "Egrave", "Eacute", "Ecircumflex", "Edieresis",
-            "Igrave", "Iacute", "Icircumflex", "Idieresis"));
-        result.init_block(0o320, vec!(
+            "Igrave", "Iacute", "Icircumflex", "Idieresis"]);
+        result.init_block(0o320, &[
             "Eth", "Ntilde", "Ograve", "Oacute",
-            "Ocircumflex", "Otilde", "Odieresis", "multiply"));
-        result.init_block(0o330, vec!(
+            "Ocircumflex", "Otilde", "Odieresis", "multiply"]);
+        result.init_block(0o330, &[
             "Oslash", "Ugrave", "Uacute", "Ucircumflex",
-            "Udieresis", "Yacute", "Thorn", "germandbls"));
-        result.init_block(0o340, vec!(
+            "Udieresis", "Yacute", "Thorn", "germandbls"]);
+        result.init_block(0o340, &[
             "agrave", "aacute", "acircumflex", "atilde",
-            "adieresis", "aring", "ae", "ccedilla"));
-        result.init_block(0o350, vec!(
+            "adieresis", "aring", "ae", "ccedilla"]);
+        result.init_block(0o350, &[
             "egrave", "eacute", "ecircumflex", "edieresis",
-            "igrave", "iacute", "icircumflex", "idieresis"));
-        result.init_block(0o360, vec!(
+            "igrave", "iacute", "icircumflex", "idieresis"]);
+        result.init_block(0o360, &[
             "eth", "ntilde", "ograve", "oacute",
-            "ocircumflex", "otilde", "odieresis", "divide"));
-        result.init_block(0o370, vec!(
+            "ocircumflex", "otilde", "odieresis", "divide"]);
+        result.init_block(0o370, &[
             "oslash", "ugrave", "uacute", "ucircumflex",
-            "udieresis", "yacute", "thorn", "ydieresis"));
+            "udieresis", "yacute", "thorn", "ydieresis"]);
         result
     };
 

--- a/src/fontmetrics.rs
+++ b/src/fontmetrics.rs
@@ -43,10 +43,7 @@ impl FontMetrics {
     /// Get the width of a specific character.
     /// The character is given in the encoding of the FontMetrics object.
     pub fn get_width(&self, char: u8) -> Option<u16> {
-        match self.widths.get(&char) {
-            Some(&w) => Some(w),
-            None => None,
-        }
+        self.widths.get(&char).cloned()
     }
 }
 

--- a/src/fontref.rs
+++ b/src/fontref.rs
@@ -37,7 +37,7 @@ impl FontRef {
             metrics,
         }
     }
-    
+
     /// Get the encoding used by the referenced font.
     pub fn get_encoding(&self) -> &Encoding {
         &self.encoding

--- a/src/fontref.rs
+++ b/src/fontref.rs
@@ -24,20 +24,20 @@ pub struct FontRef {
     metrics: Arc<FontMetrics>,
 }
 
-// Hidden from user code by not beeing a constructor method of FontRef.
-pub fn create_font_ref(
-    n: usize,
-    encoding: Encoding,
-    metrics: Arc<FontMetrics>,
-) -> FontRef {
-    FontRef {
-        n,
-        encoding,
-        metrics,
-    }
-}
-
 impl FontRef {
+    // Hidden from user code by not beeing a constructor method of FontRef.
+    pub(crate) fn new(
+        n: usize,
+        encoding: Encoding,
+        metrics: Arc<FontMetrics>,
+    ) -> Self {
+        FontRef {
+            n,
+            encoding,
+            metrics,
+        }
+    }
+    
     /// Get the encoding used by the referenced font.
     pub fn get_encoding(&self) -> &Encoding {
         &self.encoding

--- a/src/fontref.rs
+++ b/src/fontref.rs
@@ -53,16 +53,15 @@ impl FontRef {
     /// This unit is what is used in some places internally in pdf files
     /// and in some methods on a [TextObject](struct.TextObject.html).
     pub fn get_width_raw(&self, text: &str) -> u32 {
-        let mut result = 0;
-        for char in text.chars() {
-            result += u32::from(
-                self.encoding
-                    .encode_char(char)
-                    .and_then(|ch| self.metrics.get_width(ch))
-                    .unwrap_or(100),
-            );
-        }
-        result
+        text.chars().fold(0, |result, char| {
+            result
+                + u32::from(
+                    self.encoding
+                        .encode_char(char)
+                        .and_then(|ch| self.metrics.get_width(ch))
+                        .unwrap_or(100),
+                )
+        })
     }
 }
 

--- a/src/fontsource.rs
+++ b/src/fontsource.rs
@@ -5,7 +5,6 @@ use fontmetrics::{get_builtin_metrics, FontMetrics};
 use std::cmp::Eq;
 use std::hash::Hash;
 use std::io::{self, Write};
-use std::ops::Add;
 use Pdf;
 
 /// The "Base14" built-in fonts in PDF.
@@ -117,11 +116,12 @@ impl FontSource for BuiltinFont {
 
     fn get_width_raw(&self, text: &str) -> u32 {
         let metrics = self.get_metrics();
-        self.get_encoding()
-            .encode_string(text)
-            .iter()
-            .map(|&ch| u32::from(metrics.get_width(ch).unwrap_or(100)))
-            .fold(0, Add::add)
+        self.get_encoding().encode_string(text).iter().fold(
+            0,
+            |result, &ch| {
+                result + u32::from(metrics.get_width(ch).unwrap_or(100))
+            },
+        )
     }
 
     fn get_metrics(&self) -> FontMetrics {

--- a/src/graphicsstate.rs
+++ b/src/graphicsstate.rs
@@ -156,37 +156,40 @@ impl Mul for Matrix {
     }
 }
 
-#[test]
-fn test_matrix_mul_a() {
-    assert_unit(Matrix::rotate_deg(45.) * Matrix::rotate_deg(-45.));
-}
-#[test]
-fn test_matrix_mul_b() {
-    assert_unit(Matrix::uniform_scale(2.) * Matrix::uniform_scale(0.5));
-}
-#[test]
-fn test_matrix_mul_c() {
-    assert_unit(Matrix::rotate(2. * PI));
-}
-#[test]
-fn test_matrix_mul_d() {
-    assert_unit(Matrix::rotate(PI) * Matrix::uniform_scale(-1.));
-}
-
-#[allow(dead_code)]
-fn assert_unit(m: Matrix) {
-    assert_eq!(None, diff(&[1., 0., 0., 1., 0., 0.], &m.v));
-}
-
-#[allow(dead_code)]
-fn diff(a: &[f32; 6], b: &[f32; 6]) -> Option<String> {
-    let large_a = a.iter().fold(0f32, |x, &y| x.max(y));
-    let large_b = b.iter().fold(0f32, |x, &y| x.max(y));
-    let epsilon = 1e-6 * large_a.max(large_b);
-    for i in 0..6 {
-        if (a[i] - b[i]).abs() > epsilon {
-            return Some(format!("{:?} != {:?}", a, b));
-        }
+#[cfg(test)]
+mod tests {
+    use super::Matrix;
+    use std::f32::consts::PI;
+    #[test]
+    fn test_matrix_mul_a() {
+        assert_unit(Matrix::rotate_deg(45.) * Matrix::rotate_deg(-45.));
     }
-    None
+    #[test]
+    fn test_matrix_mul_b() {
+        assert_unit(Matrix::uniform_scale(2.) * Matrix::uniform_scale(0.5));
+    }
+    #[test]
+    fn test_matrix_mul_c() {
+        assert_unit(Matrix::rotate(2. * PI));
+    }
+    #[test]
+    fn test_matrix_mul_d() {
+        assert_unit(Matrix::rotate(PI) * Matrix::uniform_scale(-1.));
+    }
+
+    fn assert_unit(m: Matrix) {
+        assert_eq!(None, diff(&[1., 0., 0., 1., 0., 0.], &m.v));
+    }
+
+    fn diff(a: &[f32; 6], b: &[f32; 6]) -> Option<String> {
+        let large_a = a.iter().fold(0f32, |x, &y| x.max(y));
+        let large_b = b.iter().fold(0f32, |x, &y| x.max(y));
+        let epsilon = 1e-6 * large_a.max(large_b);
+        for i in 0..6 {
+            if (a[i] - b[i]).abs() > epsilon {
+                return Some(format!("{:?} != {:?}", a, b));
+            }
+        }
+        None
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,7 +202,7 @@ impl Pdf {
             writeln!(pdf.output, "{}", content_length)
         })?;
 
-        let mut font_oids = NamedRefs::new();
+        let mut font_oids = NamedRefs::new(fonts.len());
         for (src, r) in fonts {
             if let Some(&object_id) = self.all_font_object_ids.get(&src) {
                 font_oids.insert(r, object_id);
@@ -436,9 +436,9 @@ struct NamedRefs {
 }
 
 impl NamedRefs {
-    fn new() -> Self {
+    fn new(capacity: usize) -> Self {
         NamedRefs {
-            oids: HashMap::new(),
+            oids: HashMap::with_capacity(capacity),
         }
     }
     fn insert(&mut self, name: FontRef, oid: usize) -> Option<usize> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,7 @@ impl Pdf {
     /// Set metadata: keywords associated with the document.
     pub fn set_keywords(&mut self, keywords: &str) {
         self.document_info
-            .insert("Subject".to_string(), keywords.to_string());
+            .insert("Keywords".to_string(), keywords.to_string());
     }
     /// Set metadata: If the document was converted to PDF from another
     /// format, the name of the conforming product that created the original

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,9 +106,7 @@ impl Pdf {
     }
 
     /// Create a new PDF document, writing to `output`.
-    pub fn new(output: File) -> io::Result<Pdf> {
-        let mut output = output; // Strange but needed
-
+    pub fn new(mut output: File) -> io::Result<Pdf> {
         // TODO Maybe use a lower version?  Possibly decide by features used?
         output.write_all(b"%PDF-1.7\n%\xB5\xED\xAE\xFB\n")?;
         Ok(Pdf {
@@ -188,7 +186,7 @@ impl Pdf {
                 let start = pdf.tell()?;
                 writeln!(pdf.output, "/DeviceRGB cs /DeviceRGB CS")?;
                 let mut fonts = HashMap::new();
-                let mut outline_items: Vec<OutlineItem> = Vec::new();
+                let mut outline_items = Vec::new();
                 render_contents(&mut Canvas::new(
                     &mut pdf.output,
                     &mut fonts,

--- a/src/outline.rs
+++ b/src/outline.rs
@@ -35,9 +35,9 @@ impl OutlineItem {
         prev: Option<usize>,
         next: Option<usize>,
     ) -> io::Result<()> {
-        output.write_all(b"<< /Title (")?;
+        write!(output, "<< /Title (")?;
         output.write_all(&WIN_ANSI_ENCODING.encode_string(&self.title))?;
-        output.write_all(b")\n")?;
+        writeln!(output, ")")?;
         writeln!(output, "/Parent {} 0 R", parent_id)?;
         if let Some(id) = prev {
             writeln!(output, "/Prev {} 0 R", id)?;

--- a/src/textobject.rs
+++ b/src/textobject.rs
@@ -46,7 +46,7 @@ impl<'a> TextObject<'a> {
             encoding: WIN_ANSI_ENCODING.clone(),
         }
     }
-    
+
     /// Set the font and font-size to be used by the following text
     /// operations.
     pub fn set_font(&mut self, font: &FontRef, size: f32) -> io::Result<()> {

--- a/src/textobject.rs
+++ b/src/textobject.rs
@@ -38,15 +38,15 @@ pub struct TextObject<'a> {
     encoding: Encoding,
 }
 
-// Should not be called by user code.
-pub fn create_text_object(output: &mut Write) -> TextObject {
-    TextObject {
-        output,
-        encoding: WIN_ANSI_ENCODING.clone(),
-    }
-}
-
 impl<'a> TextObject<'a> {
+    // Should not be called by user code.
+    pub(crate) fn new(output: &'a mut Write) -> Self {
+        TextObject {
+            output,
+            encoding: WIN_ANSI_ENCODING.clone(),
+        }
+    }
+    
     /// Set the font and font-size to be used by the following text
     /// operations.
     pub fn set_font(&mut self, font: &FontRef, size: f32) -> io::Result<()> {

--- a/src/textobject.rs
+++ b/src/textobject.rs
@@ -115,10 +115,9 @@ impl<'a> TextObject<'a> {
     }
     /// Show a text.
     pub fn show(&mut self, text: &str) -> io::Result<()> {
-        self.output.write_all(b"(")?;
+        write!(self.output, "(")?;
         self.output.write_all(&self.encoding.encode_string(text))?;
-        self.output.write_all(b") Tj\n")?;
-        Ok(())
+        writeln!(self.output, ") Tj")
     }
 
     /// Show one or more text strings, allowing individual glyph positioning.
@@ -144,9 +143,9 @@ impl<'a> TextObject<'a> {
     /// # document.finish().unwrap();
     /// ```
     pub fn show_adjusted(&mut self, param: &[(&str, i32)]) -> io::Result<()> {
-        self.output.write_all(b"[")?;
+        write!(self.output, "[")?;
         for &(text, offset) in param {
-            self.output.write_all(b"(")?;
+            write!(self.output, "(")?;
             self.output.write_all(&self.encoding.encode_string(text))?;
             write!(self.output, ") {} ", offset)?
         }
@@ -154,10 +153,9 @@ impl<'a> TextObject<'a> {
     }
     /// Show a text as a line.  See also [set_leading](#method.set_leading).
     pub fn show_line(&mut self, text: &str) -> io::Result<()> {
-        self.output.write_all(b"(")?;
+        write!(self.output, "(")?;
         self.output.write_all(&self.encoding.encode_string(text))?;
-        self.output.write_all(b") '\n")?;
-        Ok(())
+        writeln!(self.output, ") '")
     }
     /// Push the graphics state on a stack.
     pub fn gsave(&mut self) -> io::Result<()> {


### PR DESCRIPTION
- Updates dependencies.
- Fixes a bug where adding keywords would just overwrite/add the Subject entry.
- Changes create_X functions to constructors that are only visible in the crate.
- Improves allocations: removed a few `clone`s, allocate space before inserting elements etc.
- Puts `graphicsstate`s tests into test module which removes dead code warning.
- Overall made more use of the standard library.